### PR TITLE
Better LocalCacher

### DIFF
--- a/Plugins/LocalCacher/Cache/CacheCore.cs
+++ b/Plugins/LocalCacher/Cache/CacheCore.cs
@@ -128,7 +128,7 @@ namespace ElectronicObserver.Observer.Cache {
 		/// <param name="url">请求的url</param>
 		/// <param name="result">本地文件地址 or 记录的修改日期</param>
 		/// <returns>下一步我们该做什么？忽略请求；返回缓存文件；验证缓存文件</returns>
-		public Direction GotNewRequest( string url, out string result ) {
+		public Direction GotNewRequest( int id, string url, out string result ) {
 			result = "";
 			string filepath = "";
 
@@ -229,15 +229,31 @@ namespace ElectronicObserver.Observer.Cache {
 					//存在本地缓存文件 -> 检查文件的最后修改时间
 					//（验证所有文件 或 只验证非资源文件）
 					if ( Configuration.Config.CacheSettings.CheckFiles > 1 || ( Configuration.Config.CacheSettings.CheckFiles > 0 && type != filetype.resources ) ) {
+						// CheckFiles = 3,　check all kinds of resource files (.swf .png .mp3)
+						if ( Configuration.Config.CacheSettings.CheckFiles == 3 && ( filepath.EndsWith( ".swf" ) || filepath.EndsWith( ".png" ) || filepath.EndsWith( ".mp3" ))) {
+							result = filepath;
+							_RecordTask( id, url, filepath );
+							return Direction.Verify_LocalFile;
+						// CheckFiles = 4, check only .swf and .png files (return .mp3 directly from cache, to be compatible with voice subtitle plugin)
+						} else if ( Configuration.Config.CacheSettings.CheckFiles == 4 ) {
+							if (filepath.EndsWith( ".mp3" )) { // Skip check, return with no-cache
+								result = filepath;
+								return Direction.NoCache_LocalFile;
+							} else if ( filepath.EndsWith( ".swf" ) || filepath.EndsWith( ".png" )) {
+								result = filepath;
+								_RecordTask( id, url, filepath );
+								return Direction.Verify_LocalFile;
+							}} else
 						//只有swf文件需要验证时间
 						if ( filepath.EndsWith( ".swf" ) ) {
 
 							//文件存在且需要验证时间
 							//-> 请求服务器验证修改时间（记录读取和保存的位置）
 							result = filepath;
-							_RecordTask( url, filepath );
+							_RecordTask( id, url, filepath );
 							return Direction.Verify_LocalFile;
 						}
+
 					}
 
 					//文件不需验证
@@ -249,7 +265,7 @@ namespace ElectronicObserver.Observer.Cache {
 
 					//缓存文件不存在
 					//-> 下载文件 （记录保存地址）
-					_RecordTask( url, filepath );
+					_RecordTask( id, url, filepath );
 					return Direction.Discharge_Response;
 				}
 			}
@@ -317,8 +333,9 @@ namespace ElectronicObserver.Observer.Cache {
 
 		}
 
-		void _RecordTask( string url, string filepath ) {
-			TaskRecord.Add( url, filepath );
+		void _RecordTask( int id, string url, string filepath ) {
+			string tkey = id.ToString()+url;
+			TaskRecord.Add( tkey, filepath );
 		}
 	}
 }

--- a/Plugins/LocalCacher/Cache/CacheCore.cs
+++ b/Plugins/LocalCacher/Cache/CacheCore.cs
@@ -232,7 +232,7 @@ namespace ElectronicObserver.Observer.Cache {
 						// CheckFiles = 3,　check all kinds of resource files (.swf .png .mp3)
 						if ( Configuration.Config.CacheSettings.CheckFiles == 3 && ( filepath.EndsWith( ".swf" ) || filepath.EndsWith( ".png" ) || filepath.EndsWith( ".mp3" ))) {
 							result = filepath;
-							_RecordTask( id, url, filepath );
+							_RecordTask( id, filepath );
 							return Direction.Verify_LocalFile;
 						// CheckFiles = 4, check only .swf and .png files (return .mp3 directly from cache, to be compatible with voice subtitle plugin)
 						} else if ( Configuration.Config.CacheSettings.CheckFiles == 4 ) {
@@ -241,7 +241,7 @@ namespace ElectronicObserver.Observer.Cache {
 								return Direction.NoCache_LocalFile;
 							} else if ( filepath.EndsWith( ".swf" ) || filepath.EndsWith( ".png" )) {
 								result = filepath;
-								_RecordTask( id, url, filepath );
+								_RecordTask( id, filepath );
 								return Direction.Verify_LocalFile;
 							}} else
 						//只有swf文件需要验证时间
@@ -250,7 +250,7 @@ namespace ElectronicObserver.Observer.Cache {
 							//文件存在且需要验证时间
 							//-> 请求服务器验证修改时间（记录读取和保存的位置）
 							result = filepath;
-							_RecordTask( id, url, filepath );
+							_RecordTask( id, filepath );
 							return Direction.Verify_LocalFile;
 						}
 
@@ -265,7 +265,7 @@ namespace ElectronicObserver.Observer.Cache {
 
 					//缓存文件不存在
 					//-> 下载文件 （记录保存地址）
-					_RecordTask( id, url, filepath );
+					_RecordTask( id, filepath );
 					return Direction.Discharge_Response;
 				}
 			}
@@ -333,9 +333,8 @@ namespace ElectronicObserver.Observer.Cache {
 
 		}
 
-		void _RecordTask( int id, string url, string filepath ) {
-			string tkey = id.ToString()+url;
-			TaskRecord.Add( tkey, filepath );
+		void _RecordTask( int id, string filepath ) {
+			TaskRecord.Add( id, filepath );
 		}
 	}
 }

--- a/Plugins/LocalCacher/Cache/TaskRecord.cs
+++ b/Plugins/LocalCacher/Cache/TaskRecord.cs
@@ -9,22 +9,22 @@ namespace ElectronicObserver.Observer.Cache
 {
 	static class TaskRecord
 	{
-		static ConcurrentDictionary<string, string> record = new ConcurrentDictionary<string, string>();
+		static ConcurrentDictionary<int, string> record = new ConcurrentDictionary<int, string>();
 		//KEY: id+url, Value: filepath
 		//只有在验证文件修改时间后，向客户端返回本地文件或者将文件保存到本地时才需要使用
 
-		static public void Add( string tkey, string filepath )
+		static public void Add( int tkey, string filepath )
 		{
 			record.AddOrUpdate( tkey, filepath, ( key, oldValue ) => filepath );
 		}
 
-		static public string GetAndRemove( string tkey )
+		static public string GetAndRemove( int tkey )
 		{
 			string ret;
 			record.TryRemove( tkey, out ret );
 			return ret;
 		}
-		static public string Get( string tkey )
+		static public string Get( int tkey )
 		{
 			string ret;
 			if ( record.TryGetValue( tkey, out ret ) )

--- a/Plugins/LocalCacher/Cache/TaskRecord.cs
+++ b/Plugins/LocalCacher/Cache/TaskRecord.cs
@@ -10,24 +10,24 @@ namespace ElectronicObserver.Observer.Cache
 	static class TaskRecord
 	{
 		static ConcurrentDictionary<string, string> record = new ConcurrentDictionary<string, string>();
-		//KEY: url, Value: filepath
+		//KEY: id+url, Value: filepath
 		//只有在验证文件修改时间后，向客户端返回本地文件或者将文件保存到本地时才需要使用
 
-		static public void Add( string url, string filepath )
+		static public void Add( string tkey, string filepath )
 		{
-			record.AddOrUpdate( url, filepath, ( key, oldValue ) => filepath );
+			record.AddOrUpdate( tkey, filepath, ( key, oldValue ) => filepath );
 		}
 
-		static public string GetAndRemove( string url )
+		static public string GetAndRemove( string tkey )
 		{
 			string ret;
-			record.TryRemove( url, out ret );
+			record.TryRemove( tkey, out ret );
 			return ret;
 		}
-		static public string Get( string url )
+		static public string Get( string tkey )
 		{
 			string ret;
-			if ( record.TryGetValue( url, out ret ) )
+			if ( record.TryGetValue( tkey, out ret ) )
 				return ret;
 			return "";
 		}

--- a/Plugins/LocalCacher/Plugin.cs
+++ b/Plugins/LocalCacher/Plugin.cs
@@ -96,8 +96,7 @@ namespace LocalCacher {
 
                 if ( oSession.responseCode == 304 ) {
 
-                    string tkey = oSession.id.ToString()+oSession.fullUrl;
-                    string filepath = TaskRecord.GetAndRemove( tkey );
+                    string filepath = TaskRecord.GetAndRemove( oSession.id );
                     //只有TaskRecord中有记录的文件才是验证的文件，才需要修改Header
                     if ( !string.IsNullOrEmpty( filepath ) ) {
 
@@ -134,8 +133,7 @@ namespace LocalCacher {
 
 			if ( Configuration.Config.CacheSettings.CacheEnabled && oSession.responseCode == 200 ) {
 
-                string tkey = oSession.id.ToString()+oSession.fullUrl;
-                string filepath = TaskRecord.GetAndRemove( tkey );
+                string filepath = TaskRecord.GetAndRemove( oSession.id );
 				if ( !string.IsNullOrEmpty( filepath ) ) {
 					if ( File.Exists( filepath ) )
                     {

--- a/Plugins/LocalCacher/Plugin.cs
+++ b/Plugins/LocalCacher/Plugin.cs
@@ -101,15 +101,18 @@ namespace LocalCacher {
                     if ( !string.IsNullOrEmpty( filepath ) ) {
 
                         //服务器返回304，文件没有修改 -> 返回本地文件
-                        oSession.ResponseBody = File.ReadAllBytes( filepath );
                         oSession.oResponse.headers.HTTPResponseCode = 200;
                         oSession.oResponse.headers.HTTPResponseStatus = "200 OK";
-                        oSession.oResponse.headers["Last-Modified"] = oSession.oRequest.headers["If-Modified-Since"];
-                        oSession.oResponse.headers["Accept-Ranges"] = "bytes";
-                        oSession.oResponse.headers.Remove( "If-Modified-Since" );
-                        oSession.oRequest.headers.Remove( "If-Modified-Since" );
+                        oSession.ResponseBody = File.ReadAllBytes( filepath );
+                        // oSession.ResponseBody will automatically correct Content-Length
                         if ( filepath.EndsWith( ".swf" ) )
-                            oSession.oResponse.headers["Content-Type"] = "application/x-shockwave-flash";
+                          oSession.oResponse.headers.Add("Content-Type", "application/x-shockwave-flash");
+                        else if ( filepath.EndsWith( ".mp3" ) )
+                          oSession.oResponse.headers.Add("Content-Type", "audio/mpeg");
+                        else if ( filepath.EndsWith( ".png" ) )
+                          oSession.oResponse.headers.Add("Content-Type", "image/png");
+                        oSession.oResponse.headers.Add("Accept-Ranges", "bytes");
+                        oSession.oResponse["Connection"] = "close";
                     }
 
                     return true;


### PR DESCRIPTION
~~Use both session id and session url instead of just session url as TKey~~,
Use Session.id instead of Session.fullUrl as TKey,
now LocalCacher can handle multiple requests with same url at the same
time. This fixes neko on Remodel scene when CheckFiles=2.

Also, this patch avoids local cache file being written multiple times when the
same file is requested more than once at the same time (this could happen
on Remodel scene) by checking if the local file is up-to-date before delete.

Added more options for CheckFiles:
- CheckFiles=3 : check all (.swf .png .mp3) resource files.
- CheckFiles=4 : check only .swf and .png, return .mp3 from local cache
  with no-cache header. This option is a workaround for compatibility with
  voice subtitle plugin (KanVoice.dll).
